### PR TITLE
feat: output all packages resulting from split in version 1.31.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Current release info
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-solara-green.svg)](https://anaconda.org/conda-forge/solara) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/solara.svg)](https://anaconda.org/conda-forge/solara) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/solara.svg)](https://anaconda.org/conda-forge/solara) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/solara.svg)](https://anaconda.org/conda-forge/solara) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-solara--assets-green.svg)](https://anaconda.org/conda-forge/solara-assets) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/solara-assets.svg)](https://anaconda.org/conda-forge/solara-assets) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/solara-assets.svg)](https://anaconda.org/conda-forge/solara-assets) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/solara-assets.svg)](https://anaconda.org/conda-forge/solara-assets) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-solara--server-green.svg)](https://anaconda.org/conda-forge/solara-server) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/solara-server.svg)](https://anaconda.org/conda-forge/solara-server) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/solara-server.svg)](https://anaconda.org/conda-forge/solara-server) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/solara-server.svg)](https://anaconda.org/conda-forge/solara-server) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-solara--ui-green.svg)](https://anaconda.org/conda-forge/solara-ui) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/solara-ui.svg)](https://anaconda.org/conda-forge/solara-ui) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/solara-ui.svg)](https://anaconda.org/conda-forge/solara-ui) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/solara-ui.svg)](https://anaconda.org/conda-forge/solara-ui) |
 
 Installing solara
 =================
@@ -51,16 +53,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `solara, solara-assets` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `solara, solara-assets, solara-server, solara-ui` can be installed with `conda`:
 
 ```
-conda install solara solara-assets
+conda install solara solara-assets solara-server solara-ui
 ```
 
 or with `mamba`:
 
 ```
-mamba install solara solara-assets
+mamba install solara solara-assets solara-server solara-ui
 ```
 
 It is possible to list all of the versions of `solara` available on your platform with `conda`:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -161,8 +161,10 @@ outputs:
     test:
       imports:
         - solara_assets
-      commands:
-        - pip check
+      # pip check fails, see https://github.com/conda-forge/solara-feedstock/pull/24#issuecomment-2072211293
+      # And https://github.com/pypa/pip/pull/11159
+      # commands:
+      #   - pip check
       requires:
         - pip
     about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.30.1" %}
-{% set build = 1 %}
+{% set version = "1.31.0" %}
+{% set build = 0 %}
 
 package:
   name: solara
@@ -7,10 +7,16 @@ package:
 
 source:
   - url: https://pypi.io/packages/source/s/solara/solara-{{ version }}.tar.gz
-    sha256: 86ca619ce2e5209ebe0bda9f6f13036eac045dfea2a5f11def336f51e93d136f
+    sha256: af8b4a9cdf70cfd9b3a35314d3dfe0c5b81f3194a68587f390edf75f26d9dd96
     folder: solara
+  - url: https://pypi.io/packages/source/s/solara-ui/solara_ui-{{ version }}.tar.gz
+    sha256: 1dfa2fbd0936652962846a3cd6e71cc3bf799e05806aa0765ffc17b61170e8e5
+    folder: solara_ui
+  - url: https://pypi.io/packages/source/s/solara-server/solara_server-{{ version }}.tar.gz
+    sha256: 9bb815a2214f50e5c3ce9e9783f285bcfcec817d262d9087157a819b3fea7100
+    folder: solara_server
   - url: https://pypi.io/packages/source/s/solara_assets/solara_assets-{{ version }}.tar.gz
-    sha256: 2aa3b6c9fae3a9843be06820f4d5cbe78bd681f5173a70dcb2d0872abbc5735a
+    sha256: 26abc7fa3e1836edb925c186af89dd444fde407cce2459a5a9efc545432a0384
     folder: solara_assets
 
 build:
@@ -27,8 +33,6 @@ outputs:
         set -euxo pipefail
         cd solara
         python -m pip install -vv --no-deps .
-      entry_points:
-        - solara = solara.__main__:main
     requirements:
       host:
         - python >=3.8
@@ -36,28 +40,93 @@ outputs:
         - pip
       run:
         - python >=3.8
+        - solara-ui
+        - solara-server
+      run_constrained:
+        # Can't use {{ pin_subpackage("solara-assets", exact=True) }}
+        # as the hashes are different
+        # TODO: revisit after https://github.com/conda-forge/staged-recipes/issues/23382
+        - solara-assets ={{ version }}=*_{{ build }}
+        - solara-server ={{ version }}=*_{{ build }}
+        - solara-ui ={{ version }}=*_{{ build }}
+
+    test:
+      imports:
+        - solara
+      commands:
+        - pip check
+        - solara --help
+      requires:
+        - pip
+
+  - name: solara-ui
+    version: {{ version }}
+    build:
+      noarch: python
+      script: |
+        set -euxo pipefail
+        cd solara_ui
+        python -m pip install -vv --no-deps .
+    requirements:
+      host:
+        - python >=3.8
+        - hatchling >=0.25
+        - pip
+      run:
+        - python >=3.8
         - reacton >=1.7.1
-        - ipywidgets
-        - cachetools
-        - filelock
+        - ipywidgets >=7.7
+        - ipyvuetify >=1.6.10
+        - ipyvue >=1.9.0
+        - requests
+        - humanize
+        # solara-ui optional dependencies follow
         - markdown
         - pymdown-extensions
-        - humanize
-        - ipyvuetify >=1.8.10
-        - ipyvue >=1.9.0
+        - pygments
+        - cachetools
+        - numpy
+        - pillow
+
+    test:
+      imports:
+        - solara
+      commands:
+        - pip check
+      requires:
+        - pip
+
+  - name: solara-server
+    version: {{ version }}
+    build:
+      noarch: python
+      script: |
+        set -euxo pipefail
+        cd solara_server
+        python -m pip install -vv --no-deps .
+      entry_points:
+        - solara = solara.__main__:main
+    requirements:
+      host:
+        - python
+        - hatchling >=0.25
+        - pip
+      run:
+        - python
         - jinja2
-        - markupsafe
         - click >=7.1.0
         - rich-click
+        - filelock
+        - ipykernel
+        - nbformat
+        - jupyter_client >=7.0.0
+        - solara-ui
+        # solara-server optional dependencies follow
         - uvicorn
         - websockets
         - starlette
-        - jupyter_client >=7.0.0
-        - watchdog
-        - requests
-        - nbformat
-        - ipykernel
         - watchfiles
+        - watchdog
       run_constrained:
         # Can't use {{ pin_subpackage("solara-assets", exact=True) }}
         # as the hashes are different
@@ -88,6 +157,7 @@ outputs:
       run:
         - python
         - solara
+
     test:
       imports:
         - solara_assets


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Reset the build number to `0` (if the version changed)
* [ ] Ensured the license file is being packaged.

In `solara` version `1.31.0`, the package was split into different parts:
- The pytest plugin became `pytest-ipywidgets`
- Solara itself was split into `solara-ui` and `solara-server`

These packages are all in the widgetti/solara repository, so it makes sense to output them all from here. This should output all packages, and ensure correct interdependency.
