### PR TITLE
fix: builds fail with ModuleNotFoundError for hatchling

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set build = 0 %}
 
 package:
-  name: solara
+  name: solara-suite
   version: {{ version }}
 
 source:
@@ -192,6 +192,7 @@ about:
 
 
 extra:
+  feedstock-name: solara
   recipe-maintainers:
     - maartenbreddels
     - mariobuikhuizen


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

Builds for new versions fail with
```
ModuleNotFoundError: No module named 'hatchling'
```
Even though `hatchling` is listed in all dependencies. Trying some stuff here.